### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,19 +7,13 @@ updates:
     schedule:
       interval: daily
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: daily
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/