### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,5 +1,7 @@
 ---
 name: PHP
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/reload/cpr/security/code-scanning/2](https://github.com/reload/cpr/security/code-scanning/2)

The best way to fix the problem is to add the `permissions` key with value `contents: read` to the workflow. This explicitly limits the permissions granted to the `GITHUB_TOKEN` for all jobs (both current and future additions that forget permissions at the job level). To do so, edit the `.github/workflows/php.yml` file and add the following block immediately after the `name: PHP` (line 2) and before the `on:` trigger (line 4). No further changes or imports are required. This will not affect workflow functionality, since no job needs more than read access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
